### PR TITLE
using lock-free hash table for table_dictionary

### DIFF
--- a/src/database_impl.h
+++ b/src/database_impl.h
@@ -22,7 +22,6 @@
 #include <lineairdb/tx_status.h>
 
 #include <functional>
-#include <shared_mutex>
 #include <utility>
 
 #include "callback/callback_manager.h"

--- a/src/index/precision_locking_index/range_index/precision_locking.cpp
+++ b/src/index/precision_locking_index/range_index/precision_locking.cpp
@@ -20,7 +20,6 @@
 #include <atomic>
 #include <cassert>
 #include <functional>
-#include <mutex>
 #include <string_view>
 #include <vector>
 

--- a/src/recovery/checkpoint_manager.hpp
+++ b/src/recovery/checkpoint_manager.hpp
@@ -24,7 +24,6 @@
 #include <atomic>
 #include <chrono>
 #include <msgpack.hpp>
-#include <shared_mutex>
 #include <string_view>
 #include <thread>
 

--- a/src/table/table.h
+++ b/src/table/table.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <memory>
-#include <shared_mutex>
 #include <string>
 
 #include "index/concurrent_table.h"

--- a/src/table/table_dictionary.hpp
+++ b/src/table/table_dictionary.hpp
@@ -2,8 +2,9 @@
 
 #include <memory>
 #include <string>
-#include <unordered_map>
+#include <utility>
 
+#include "index/precision_locking_index/point_index/mpmc_concurrent_set_impl.hpp"
 #include "table/table.h"
 
 namespace LineairDB {
@@ -14,41 +15,31 @@ class TableDictionary {
 
   bool CreateTable(std::string_view table_name, EpochFramework& epoch_framework,
                    const Config& config) {
-    std::unique_lock<std::shared_mutex> lk(schema_mutex_);
-    if (tables_.find(std::string(table_name)) != tables_.end()) {
+    if (tables_.Get(table_name) != nullptr) {
       return false;
     }
-    auto table = std::make_unique<Table>(epoch_framework, config,
-                                         std::string(table_name));
-    auto [it, inserted] =
-        tables_.emplace(std::string(table_name), std::move(table));
-    return inserted;
+    tables_.Put(table_name,
+                new Table(epoch_framework, config, std::string(table_name)));
+    return true;
   }
 
   std::optional<Table*> GetTable(const std::string_view table_name) {
-    std::shared_lock lk(schema_mutex_);
-    auto it = tables_.find(std::string(table_name));
-    if (it == tables_.end()) {
-      return std::nullopt;  // Table not found
+    auto* table = tables_.Get(table_name);
+    if (table == nullptr) {
+      return std::nullopt;
     }
-    return it->second.get();
+    return table;
   }
 
   void ForEachTable(std::function<void(Table&)> f) {
-    std::shared_lock lk(schema_mutex_);
-    for (auto& [name, table] : tables_) {
-      f(*table);
-    }
+    tables_.ForEach([&](std::string_view, Table& table) {
+      f(table);
+      return true;
+    });
   }
 
  private:
-  std::unordered_map<std::string, std::unique_ptr<Table>> tables_;
-
-  // @TODO  We should remove this mutex by using concurrent hash map (e.g.,
-  // MPMCConcurrentSet in index/precision_locking_index/point_index directory)
-  // It is very inefficient to acquire this lock for every read write
-  // transactions only for GetTable().
-  std::shared_mutex schema_mutex_;
+  LineairDB::Index::MPMCConcurrentSetImpl<Table> tables_;
 };
 
 }  // namespace LineairDB


### PR DESCRIPTION
Benchmark results in my environment:
```shell
> lscpu
Architecture:             x86_64
  CPU op-mode(s):         32-bit, 64-bit
  Address sizes:          46 bits physical, 48 bits virtual
  Byte Order:             Little Endian
CPU(s):                   20
  On-line CPU(s) list:    0-19
Vendor ID:                GenuineIntel
  Model name:             13th Gen Intel(R) Core(TM) i5-13500

# Build
> clang++ --version
Ubuntu clang version 14.0.0-1ubuntu1.1
> cmake .. DCMAKE_BUILD_TYPE=Release
> make
> bench/ycsb -d 3000 -H true -t 1 -q 40 -e 40 -w a -l true -C 0.99 -R 10000`
```
## Results

### shared_mutex
https://github.com/LineairDB/LineairDB/pull/629/commits/57082abe263deb5d990f2a3111d0ecbcefc754e4 (shared_mutex)
```
[Thread 26773] [2025-08-31 13:51:47.399] [info] [benchmark.cpp:261] YCSB: Benchmark completed. elapsed time: 3000ms, commits: 9610122, aborts: 1696950, tps: 3203374 [+0msec]
```
TPS: 3203374

## origin/main
https://github.com/LineairDB/LineairDB/commit/268608f8b125e1ef0e4e68d3d986ef8f93b11ff8 (origin/main upstream HEAD)
```
[Thread 24990] [2025-08-31 13:50:14.605] [info] [benchmark.cpp:261] YCSB: Benchmark completed. elapsed time: 3000ms, commits: 13736413, aborts: 1764766, tps: 4578804 [+0msec]
```
TPS: 4578804

### lock-free hash table
[fe39906a66454b81fd158bcbba2fe87338d87e8e](https://github.com/wasanemon/LineairDB-ssh/commit/09bfce9bbb5743898d8aade11ceb6cd5c08f4758) (this PR)

```
[Thread 74389] [2025-08-31 15:22:45.625] [info] [benchmark.cpp:261] YCSB: Benchmark completed. elapsed time: 3000ms, commits: 10242014, aborts: 1750579, tps: 3414004 [+0msec]
```
TPS: 3414004

---

I also removed some unused includes.
Peak performance hasn't returned on my environment, so I suspect other details related to table_functionality are causing the performance degradation.
However, I'm concerned about scalability when varying the number of threads. 

@wasanemon  Could you review & benchmark this patch?